### PR TITLE
Fix gitignore to ignore GEOSgcm_GridComp

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,7 @@
 *#
 .#*
 **/CVS/
+
+/@GEOSgcm_GridComp
+/GEOSgcm_GridComp
+/GEOSgcm_GridComp@


### PR DESCRIPTION
As discovered by @biljanaorescanin when GEOSldas_GridComp was split, the `.gitignore` neglected to ignore GEOSgcm_GridComp. So, when you do a mepo status:

```
❯ mepo status
Checking status...
GEOSldas          | (b) develop
env               | (t) v4.23.0 (DH)
cmake             | (t) v3.41.0 (DH)
ecbuild           | (t) geos/v1.3.0 (DH)
NCEP_Shared       | (t) v1.3.0 (DH)
GMAO_Shared       | (t) v1.9.7 (DH)
GEOS_Util         | (t) v2.0.7 (DH)
MAPL              | (t) v2.44.1 (DH)
GEOSldas_GridComp | (b) develop (DH, 66f434b)
   | @GEOSgcm_GridComp/: untracked file
GEOSgcm_GridComp  | (b) develop (DH, 7110ca94)
```

This is because the `.gitignore` in the old monorepo did have it, but the new repo now has a new one and I missed this. Mea culpa.