### PR TITLE
Update .gitignore to remove GEOSgcm_GridComp references

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,7 +5,3 @@
 *#
 .#*
 **/CVS/
-
-/@GEOSgcm_GridComp
-/GEOSgcm_GridComp
-/GEOSgcm_GridComp@


### PR DESCRIPTION
Remove `GEOSgcm_GridComp` references in `.gitignore`.
(Minimal cleanup from #27.)