### PR TITLE
more optimal distribution of cubed-sphere grid

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- More optimal distribution of cubed-sphere grid
+
 ### Fixed
 
 ### Removed


### PR DESCRIPTION
When tiles are concentrated in one face, almost all processors are allocated to them , which may lead to too many processors on one face ( a processor may have 0 or 1 cell, which would crash regrider) . This PR tries to avoid that and stop when there are too many processors. 