### PR TITLE
Support HISTORY output of ASNOW alone from ENSAVG Gridcomp

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Bug fix and improved efficiency in matlab script for generation of mwRTM_param.
 - Changed EXPDIR to absolute path for POSTPROC_HIST>0 option to work.
+- Support HISTORY output of ASNOW alone from ENSAVG Gridcomp.
 
 ### Removed
 

--- a/GEOSens_GridComp/GEOS_EnsGridComp.F90
+++ b/GEOSens_GridComp/GEOS_EnsGridComp.F90
@@ -2924,11 +2924,11 @@ contains
     VERIFY_(status)
     call MAPL_GetPointer(export, AVETSNOW_enavg,  'AVETSNOW' ,rc=status)
     VERIFY_(status)
-    call MAPL_GetPointer(export, FRSAT_enavg,  'FRSAT' ,rc=status)
+    call MAPL_GetPointer(export, FRSAT_enavg,  'FRSAT' , alloc=.true., rc=status)   ! always allocate to support ASNOW_enavg calc below
     VERIFY_(status)
-    call MAPL_GetPointer(export, FRUST_enavg,  'FRUST' ,rc=status)
+    call MAPL_GetPointer(export, FRUST_enavg,  'FRUST' , alloc=.true., rc=status)   ! always allocate to support ASNOW_enavg calc below
     VERIFY_(status)
-    call MAPL_GetPointer(export, FRWLT_enavg,  'FRWLT' ,rc=status)
+    call MAPL_GetPointer(export, FRWLT_enavg,  'FRWLT' , alloc=.true., rc=status)   ! always allocate to support ASNOW_enavg calc below
     VERIFY_(status)
     call MAPL_GetPointer(export, SNOWMASS_enavg,  'SNOWMASS' ,rc=status)
     VERIFY_(status)


### PR DESCRIPTION
Addresses #48.

Solution: Calculate the ens average of ASNOW from scratch (like that of the other tile area fractions FRSAT, FRUST, and FRWLT). 

Note: Always allocating ens avg of fractional area variables in GEOS_EnsGridComp.F90 does not work without doing the same in GEOS_CatchGridComp.F90.

cc: @mathomp4, @weiyuan-jiang @saraqzhang 
