### PR TITLE
Specify only ntasks_model for SLURM resource request

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Specify ntasks_model only for slurm resource request
+- Specify only ntasks_model for SLURM resource request.
 - Revisions for handling of Nens and special nml and mwtrm path/files in coupled land-atm DAS.
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Specify ntasks_model only for slurm resource request
+
 ### Fixed
 
 ### Removed

--- a/GEOSldas_App/ldas_setup
+++ b/GEOSldas_App/ldas_setup
@@ -59,7 +59,7 @@ class LDASsetup:
         # ------
         # Required resource manager input fields
         # ------
-        rqdRmInpKeys    = ['account', 'walltime', 'ntasks_model', 'ntasks-per-node']
+        rqdRmInpKeys    = ['account', 'walltime', 'ntasks_model']
         # ------
         # Optional resource manager input fields
         # ------
@@ -613,8 +613,6 @@ class LDASsetup:
             self.rqdRmInp['account']         = cmdLineArgs['account']
             self.rqdRmInp['walltime']        = "01:00:00" 
             self.rqdRmInp['ntasks_model']    = 120
-            self.rqdRmInp['ntasks-per-node'] =  46                   # 46 works on Cascade Lake and Milan 
-
 
 
         # print rm inputs
@@ -649,18 +647,9 @@ class LDASsetup:
         self.rstdir = self.outdir+'/'+self.rqdExeInp['EXP_DOMAIN']+'/rs/'
         self.exefyl = self.blddirLn+exefyl
 
-        my_ntasks_per_node = int(self.rqdRmInp['ntasks-per-node'])
-
-        # default number of nodes
-        my_nodes = self.rqdRmInp['ntasks_model'] // my_ntasks_per_node
-        if self.rqdRmInp['ntasks_model'] % my_ntasks_per_node > 0 :
-           my_nodes = my_nodes + 1
-
         # default is set to 0 ( no output server)
         if 'oserver_nodes' not in self.optRmInp :
            self.optRmInp['oserver_nodes'] = 0
-
-        self.optRmInp['nodes'] = my_nodes + int(self.optRmInp['oserver_nodes'])
 
         if (int(self.optRmInp['oserver_nodes']) >=1) :
            self.rqdExeInp['WRITE_RESTART_BY_OSERVER'] = "YES"
@@ -1588,8 +1577,7 @@ class LDASsetup:
                   SBATCHQSUB         = SBATCHQSUB,
                   MY_ACCOUNT         = self.rqdRmInp['account'],
                   MY_WALLTIME        = self.rqdRmInp['walltime'],
-                  MY_NODES           = str(self.optRmInp['nodes']),
-                  MY_NTASKS_PER_NODE = str(self.rqdRmInp['ntasks-per-node']),
+                  MY_NTASKS_MODEL    = str(self.rqdRmInp['ntasks_model']),
                   MY_CONSTRAINT      = constraint,
                   MY_OSERVER_NODES   = str(self.optRmInp['oserver_nodes']),
                   MY_WRITERS_NPES    = str(self.optRmInp['writers-per-node']),
@@ -1848,9 +1836,6 @@ def _printRmInputKeys(rqdRmInpKeys, optRmInpKeys):
     print ('#                      [At NCCS: Use command "getsponsor" to see available account number(s).]' )
     print ('# - walltime         = walltime requested; format is HH:MM:SS (hours/minutes/seconds)')
     print ('# - ntasks_model     = number of processors requested for the model (typically 126; output server is not included)')
-    print ('# - ntasks-per-node  = number of tasks per node (typically 46 for Cascade Lake and 126 for Milan)')
-    print ('#                      [If >46, Milan nodes will be allocated, else Cascade Lake or Milan.]')
-    print ('#                      [NCCS recommends <=46 for Cascade Lake and <=126 for Milan.]')
     print ('#')
     for key in rqdRmInpKeys:
         print (key + ':')
@@ -1861,8 +1846,8 @@ def _printRmInputKeys(rqdRmInpKeys, optRmInpKeys):
     print ('# NOTE:')
     print ('# - job_name         = name of experiment; default is "exp_id"')
     print ('# - qos              = quality-of-service; do not specify by default; specify "debug" for faster but limited service.')
-    print ('# - oserver_nodes    = number of nodes for oserver ( default is 0 )')
-    print ('# - writers-per-node = tasks per oserver_node for writing ( default is 5 ),')
+    print ('# - oserver_nodes    = number of nodes for oserver ( default is 0, for future use )')
+    print ('# - writers-per-node = tasks per oserver_node for writing ( default is 5, for future use ),')
     print ('#      IMPORTANT REQUIREMENT: total #writers = writers-per-node * oserver_nodes >= 2')
     print ('#      Jobs will hang when oserver_nodes = writers-per-node = 1.')
     print ('#')

--- a/GEOSldas_App/lenkf_j_template.py
+++ b/GEOSldas_App/lenkf_j_template.py
@@ -12,7 +12,7 @@ job_directive = {"NCCS": '''#!/bin/csh -f
 #SBATCH --error={MY_EXPDIR}/scratch/GEOSldas_err_txt
 #SBATCH --account={MY_ACCOUNT}
 #SBATCH --time={MY_WALLTIME}
-#SBATCH --nodes={MY_NODES} --ntasks-per-node={MY_NTASKS_PER_NODE}
+#SBATCH --ntasks={MY_NTASKS_MODEL}
 #SBATCH --job-name={MY_JOB}
 #SBATCH --qos={MY_QOS}
 #SBATCH --constraint={MY_CONSTRAINT}


### PR DESCRIPTION
Revise ldas_setup and lenkf_j_template.py so that only "ntasks" is specified in SLURM directives.  Previously, "nodes" and "ntasks-per-node" were specified.  

By specifying only "ntasks", SLURM can efficiently allocate the appropriate number of either Milan or Cascade Lake nodes.  

Previously, by specifying "ntasks-per-node" we had to either (i) effectively constrain to Milan nodes (nodes=1, ntasks-per-node=126) or (ii), by choosing ntasks-per-node=46 and nodes=3, end up with a potentially very wasteful allocation of several Milan nodes if Cascade Lakes are too busy (depending on how exactly SLURM translates these directives into allocations).  

The downside of specifying only "ntasks" is that we can no longer set up OSERVER via ldas_setup.  But OSERVER turned out not to provide any efficiency gains for LDAS and was never used in practice.  Note that manual editing of the lenkf.j job file (after running ldas_setup) still allows for the use of OSERVER.

---

Successfully 0-diff tested by @gmao-rreichle.   For the assim tests, results were not 0-diff because of layout changes caused by the present PR.  (Results for assimilation runs have been layout-dependent for a long time.)  The non-0-diff results are within roundoff and scientifically correct. 

Impact on automated nightly tests: The line that specifies "ntasks-per-node" needs to be removed from the ./run/*.slurm batch input config files.

