### PR TITLE
Revised processing of HISTORY template (GEOSldas_HIST.rc)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Added EASE to Latlon and Cubed-Sphere to EASE history outputs
 - Added optional SLURM "constraint".
 - Added functionality to run on tile space of stretched cube-sphere grids.
 - Added python package for post-processing ObsFcstAna output.
@@ -19,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Revised processing of HISTORY template (GEOSldas_HIST.rc).
 - Switch to using EASE grid tools in MAPL.
 - Specify only ntasks_model for SLURM resource request.
 - Revisions for handling of Nens and special nml and mwtrm path/files in coupled land-atm DAS.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Added EASE to Latlon and Cubed-Sphere to EASE history outputs
 - Added optional SLURM "constraint".
 - Added functionality to run on tile space of stretched cube-sphere grids.
 - Added python package for post-processing ObsFcstAna output.

--- a/GEOSldas_App/GEOSldas_HIST.rc
+++ b/GEOSldas_App/GEOSldas_HIST.rc
@@ -6,7 +6,7 @@
 #    "#CUBE            'tavg24_2d_lnd_Nx'"
 #  does *not* mean that the 'lnd' output will be on a cube-sphere grid. 
 
-#CUBE VERSION: 1
+VERSION: 1
 
 # Must edit 'EXPID' manually if HISTORY file is re-used without going  
 #  through "ldas_setup".
@@ -15,9 +15,10 @@ EXPID:  GEOSldas_expid
 
 COLLECTIONS:
 #EASE            'tavg24_1d_lfs_Nt'
-#CUBE            'tavg24_2d_lfs_Nx'	
-#EASE            'tavg24_1d_lnd_Nt'	
-#CUBE            'tavg24_2d_lnd_Nx'
+                 'tavg24_2d_lfs_Nx'
+#EASE            'tavg24_1d_lnd_Nt'
+                 'tavg24_2d_lnd_Nx'
+#CUBE            'tavg24_2d_lnd_EASE'
 #ASSIM           'SMAP_L4_SM_gph'
 #                'inst1_1d_lnr_Nt'
 #                'catch_progn_incr'
@@ -29,24 +30,28 @@ COLLECTIONS:
 #                'tavg24_1d_glc_Nt'
            ::
 
-#CUBE GRID_LABELS: PC720x361-DC
-#CUBE              PC1440x721-DC
+GRID_LABELS: PC720x361-DC
+             PC1440x721-DC
+             EASEv2_M36
+      ::
 
-#CUBE      ::
+PC720x361-DC.GRID_TYPE: LatLon
+PC720x361-DC.IM_WORLD: 720
+PC720x361-DC.JM_WORLD: 361
+PC720x361-DC.POLE: PC
+PC720x361-DC.DATELINE: DC
+PC720x361-DC.LM: 1
 
-#CUBE PC720x361-DC.GRID_TYPE: LatLon
-#CUBE PC720x361-DC.IM_WORLD: 720
-#CUBE PC720x361-DC.JM_WORLD: 361
-#CUBE PC720x361-DC.POLE: PC
-#CUBE PC720x361-DC.DATELINE: DC
-#CUBE PC720x361-DC.LM: 1
+PC1440x721-DC.GRID_TYPE: LatLon
+PC1440x721-DC.IM_WORLD: 1440
+PC1440x721-DC.JM_WORLD: 721
+PC1440x721-DC.POLE: PC
+PC1440x721-DC.DATELINE: DC
+PC1440x721-DC.LM: 1
 
-#CUBE PC1440x721-DC.GRID_TYPE: LatLon
-#CUBE PC1440x721-DC.IM_WORLD: 1440
-#CUBE PC1440x721-DC.JM_WORLD: 721
-#CUBE PC1440x721-DC.POLE: PC
-#CUBE PC1440x721-DC.DATELINE: DC
-#CUBE PC1440x721-DC.LM: 1
+EASEv2_M36.GRID_TYPE: EASE
+EASEv2_M36.GRIDNAME: EASEv2_M36
+EASEv2_M36.LM: 1
 
 # Detailed definition of the collections listed above 
 #
@@ -322,6 +327,74 @@ COLLECTIONS:
 >>>HIST_IRRIG<<<        'IRRIGRATE'  , 'GridComp'  ,
                                ::
 
+
+  tavg24_2d_lnd_EASE.format:        'CFIO',
+  tavg24_2d_lnd_EASE.descr:         '2d,Daily,Time-Averaged,Single-Level,Assimilation,Land Surface Diagnostics',
+  tavg24_2d_lnd_EASE.nbits:        12,
+  tavg24_2d_lnd_EASE.template:      '%y4%m2%d2_%h2%n2z.nc4',
+  tavg24_2d_lnd_EASE.mode:          'time-averaged',
+  tavg24_2d_lnd_EASE.frequency:     240000,
+  tavg24_2d_lnd_EASE.ref_time:      000000,
+  tavg24_2d_lnd_EASE.regrid_exch:   '../input/tile.data'
+  tavg24_2d_lnd_EASE.regrid_name:   'GRIDNAME'
+#  tavg24_2d_lnd_EASE.regrid_method: 'BILINEAR_MONOTONIC' ,
+  tavg24_2d_lnd_EASE.grid_label:    EASEv2_M36
+  tavg24_2d_lnd_EASE.deflate:       2,
+  tavg24_2d_lnd_EASE.fields:     'GRN'        , 'VEGDYN'  ,
+                               'LAI'        , 'VEGDYN'  ,
+                               'WET3'       , 'GridComp'  , 'GWETPROF'     ,
+                               'WET2'       , 'GridComp'  , 'GWETROOT'     ,
+                               'WET1'       , 'GridComp'  , 'GWETTOP'      ,
+                               'WCPR'       , 'GridComp'  , 'PRMC'         ,
+                               'WCRZ'       , 'GridComp'  , 'RZMC'         ,
+                               'WCSF'       , 'GridComp'  , 'SFMC'         ,
+                               'CAPAC'      , 'GridComp'  , 'INTRWATR'     ,
+                               'TPSNOW'     , 'GridComp'  , 'TPSNOWLAND'   ,
+                               'TPUNST'     , 'GridComp'  , 'TUNSTLAND'    ,
+                               'TPSAT'      , 'GridComp'  , 'TSATLAND'     ,
+                               'TPWLT'      , 'GridComp'  , 'TWLTLAND'     ,
+                               'TPSURF'     , 'GridComp'  , 'TSURFLAND'    ,
+                               'TP1'        , 'GridComp'  , 'TSOIL1'       ,         # CATCH GC: TP1,  ENSAVG GC: TSOIL1TILE
+                               'TP2'        , 'GridComp'  , 'TSOIL2'       ,         # ...
+                               'TP3'        , 'GridComp'  , 'TSOIL3'       ,         # ...
+                               'TP4'        , 'GridComp'  , 'TSOIL4'       ,         # ...
+                               'TP5'        , 'GridComp'  , 'TSOIL5'       ,         # ...
+                               'TP6'        , 'GridComp'  , 'TSOIL6'       ,         # ...
+                               'PRLAND'     , 'GridComp'  , 'PRECTOTCORRLAND'  ,     # assume "corrected" precip
+                               'SNOLAND'    , 'GridComp'  , 'PRECSNOCORRLAND'  ,     # assume "corrected" precip
+                               'TSLAND'     , 'GridComp'  , 'SNOMASLAND'   ,
+                               'SNOWDP'     , 'GridComp'  , 'SNODPLAND'    ,
+                               'EVPSOI'     , 'GridComp'  , 'LHLANDSOIL'   ,
+                               'EVPVEG'     , 'GridComp'  , 'LHLANDTRNS'   ,
+                               'EVPINT'     , 'GridComp'  , 'LHLANDINTR'   ,
+                               'EVPICE'     , 'GridComp'  , 'LHLANDSBLN'   ,
+                               'RUNSURF'    , 'GridComp'  , 'RUNSURFLAND'  ,
+                               'BASEFLOW'   , 'GridComp'  , 'BASEFLOWLAND' ,
+                               'SMLAND'     , 'GridComp'  ,
+                               'QINFIL'     , 'GridComp'  , 'QINFILLAND'   ,
+                               'FRUST'      , 'GridComp'  , 'FRLANDUNST'   ,
+                               'FRSAT'      , 'GridComp'  , 'FRLANDSAT'    ,
+                               'ASNOW'      , 'GridComp'  , 'FRLANDSNO'    ,
+                               'FRWLT'      , 'GridComp'  , 'FRLANDWLT'    ,
+                               'DFPARLAND'  , 'GridComp'  , 'PARDFLAND'    ,
+                               'DRPARLAND'  , 'GridComp'  , 'PARDRLAND'    ,
+                               'SHLAND'     , 'GridComp'  ,
+                               'LHLAND'     , 'GridComp'  ,
+                               'EVLAND'     , 'GridComp'  ,
+                               'LWLAND'     , 'GridComp'  ,
+                               'SWLAND'     , 'GridComp'  ,
+                               'GHLAND'     , 'GridComp'  ,
+                               'TWLAND'     , 'GridComp'  ,
+                               'TELAND'     , 'GridComp'  ,
+                               'DWLAND'     , 'GridComp'  , 'WCHANGELAND'  ,
+                               'DHLAND'     , 'GridComp'  , 'ECHANGELAND'  ,
+                               'SPLAND'     , 'GridComp'  , 'SPSHLAND'     ,
+#                               'SPLH'       , 'GridComp'  , 'SPLHLAND'     ,        # works for Catch only, not yet for CatchCN
+                               'SPWATR'     , 'GridComp'  , 'SPEVLAND'     ,
+                               'SPSNOW'     , 'GridComp'  , 'SPSNLAND'     ,
+                               'PEATCLSM_WATERLEVEL', 'GridComp'  ,
+                               'PEATCLSM_FSWCHANGE' , 'GridComp'  ,
+                           ::
 
   const_1d_lnd_Nt.descr:       'Tile-space,Constant,Time-invariant,Single-Level,Assimilation,Land Surface Model Parameters',
   const_1d_lnd_Nt.template:    '%y4%m2%d2_%h2%n2z.bin',

--- a/GEOSldas_App/GEOSldas_HIST.rc
+++ b/GEOSldas_App/GEOSldas_HIST.rc
@@ -1,25 +1,23 @@
 # Sample HISTORY.rc file for GEOSldas
 #
 # This HISTORY template is edited by "ldas_setup" via "process_hist.csh".  
-# The strings '#ASSIM', '#EASE', and '#CUBE' are *not* linked to MAPL HISTORY 
-# functionality.  For example, the line 
-#    "#CUBE            'tavg24_2d_lnd_Nx'"
-#  does *not* mean that the 'lnd' output will be on a cube-sphere grid. 
 
 VERSION: 1
 
-# Must edit 'EXPID' manually if HISTORY file is re-used without going  
-#  through "ldas_setup".
-#
+# Must edit 'EXPID' manually if HISTORY file is re-used without going through "ldas_setup".
+
 EXPID:  GEOSldas_expid
 
+# ------------------------------------------------------------------------------------------------
+
+# pre-defined Collections
+
 COLLECTIONS:
-#EASE            'tavg24_1d_lfs_Nt'
-                 'tavg24_2d_lfs_Nx'
-#EASE            'tavg24_1d_lnd_Nt'
-                 'tavg24_2d_lnd_Nx'
-#CUBE            'tavg24_2d_lnd_EASE'
-#ASSIM           'SMAP_L4_SM_gph'
+#OUT1d           'tavg24_1d_lfs_Nt'
+#OUT2d           'tavg24_2d_lfs_Nx'
+#OUT1d           'tavg24_1d_lnd_Nt'
+#OUT2d           'tavg24_2d_lnd_Nx'
+#                'SMAP_L4_SM_gph'
 #                'inst1_1d_lnr_Nt'
 #                'catch_progn_incr'
 #                'inst3_1d_lndfcstana_Nt'
@@ -30,28 +28,34 @@ COLLECTIONS:
 #                'tavg24_1d_glc_Nt'
            ::
 
+# --------------------------------------------------------------------------------------------------
+
+# 2d output can be on the following grids (see [COLLECTION_NAME].grid_label])
+
 GRID_LABELS: PC720x361-DC
              PC1440x721-DC
              EASEv2_M36
       ::
 
-PC720x361-DC.GRID_TYPE: LatLon
-PC720x361-DC.IM_WORLD: 720
-PC720x361-DC.JM_WORLD: 361
-PC720x361-DC.POLE: PC
-PC720x361-DC.DATELINE: DC
-PC720x361-DC.LM: 1
+PC720x361-DC.GRID_TYPE:  LatLon
+PC720x361-DC.IM_WORLD:   720
+PC720x361-DC.JM_WORLD:   361
+PC720x361-DC.POLE:       PC
+PC720x361-DC.DATELINE:   DC
+PC720x361-DC.LM:         1
 
 PC1440x721-DC.GRID_TYPE: LatLon
-PC1440x721-DC.IM_WORLD: 1440
-PC1440x721-DC.JM_WORLD: 721
-PC1440x721-DC.POLE: PC
-PC1440x721-DC.DATELINE: DC
-PC1440x721-DC.LM: 1
+PC1440x721-DC.IM_WORLD:  1440
+PC1440x721-DC.JM_WORLD:   721
+PC1440x721-DC.POLE:      PC
+PC1440x721-DC.DATELINE:  DC
+PC1440x721-DC.LM:        1
 
-EASEv2_M36.GRID_TYPE: EASE
-EASEv2_M36.GRIDNAME: EASEv2_M36
-EASEv2_M36.LM: 1
+EASEv2_M36.GRID_TYPE:    EASE
+EASEv2_M36.GRIDNAME:     EASEv2_M36
+EASEv2_M36.LM:           1
+
+# --------------------------------------------------------------------------------------------------
 
 # Detailed definition of the collections listed above 
 #
@@ -224,15 +228,16 @@ EASEv2_M36.LM: 1
 
   tavg24_2d_lnd_Nx.format:        'CFIO',
   tavg24_2d_lnd_Nx.descr:         '2d,Daily,Time-Averaged,Single-Level,Assimilation,Land Surface Diagnostics',
-  tavg24_2d_lnd_Nx.nbits:        12,
+  tavg24_2d_lnd_Nx.nbits:         12,
   tavg24_2d_lnd_Nx.template:      '%y4%m2%d2_%h2%n2z.nc4',
   tavg24_2d_lnd_Nx.mode:          'time-averaged',
   tavg24_2d_lnd_Nx.frequency:     240000,
   tavg24_2d_lnd_Nx.ref_time:      000000,
-  tavg24_2d_lnd_Nx.regrid_exch:   '../input/tile.data'
-  tavg24_2d_lnd_Nx.regrid_name:   'GRIDNAME'
+  tavg24_2d_lnd_Nx.regrid_exch:   '../input/tile.data',
+  tavg24_2d_lnd_Nx.regrid_name:   'GRIDNAME',
 #  tavg24_2d_lnd_Nx.regrid_method: 'BILINEAR_MONOTONIC' ,                           
-  tavg24_2d_lnd_Nx.grid_label:    PC720x361-DC
+  tavg24_2d_lnd_Nx.grid_label:    PC720x361-DC,
+#  tavg24_2d_lnd_Nx.grid_label:   EASEv2_M36,
   tavg24_2d_lnd_Nx.deflate:       2,
   tavg24_2d_lnd_Nx.fields:     'GRN'        , 'VEGDYN'  ,
                                'LAI'        , 'VEGDYN'  ,
@@ -327,74 +332,6 @@ EASEv2_M36.LM: 1
 >>>HIST_IRRIG<<<        'IRRIGRATE'  , 'GridComp'  ,
                                ::
 
-
-  tavg24_2d_lnd_EASE.format:        'CFIO',
-  tavg24_2d_lnd_EASE.descr:         '2d,Daily,Time-Averaged,Single-Level,Assimilation,Land Surface Diagnostics',
-  tavg24_2d_lnd_EASE.nbits:        12,
-  tavg24_2d_lnd_EASE.template:      '%y4%m2%d2_%h2%n2z.nc4',
-  tavg24_2d_lnd_EASE.mode:          'time-averaged',
-  tavg24_2d_lnd_EASE.frequency:     240000,
-  tavg24_2d_lnd_EASE.ref_time:      000000,
-  tavg24_2d_lnd_EASE.regrid_exch:   '../input/tile.data'
-  tavg24_2d_lnd_EASE.regrid_name:   'GRIDNAME'
-#  tavg24_2d_lnd_EASE.regrid_method: 'BILINEAR_MONOTONIC' ,
-  tavg24_2d_lnd_EASE.grid_label:    EASEv2_M36
-  tavg24_2d_lnd_EASE.deflate:       2,
-  tavg24_2d_lnd_EASE.fields:     'GRN'        , 'VEGDYN'  ,
-                               'LAI'        , 'VEGDYN'  ,
-                               'WET3'       , 'GridComp'  , 'GWETPROF'     ,
-                               'WET2'       , 'GridComp'  , 'GWETROOT'     ,
-                               'WET1'       , 'GridComp'  , 'GWETTOP'      ,
-                               'WCPR'       , 'GridComp'  , 'PRMC'         ,
-                               'WCRZ'       , 'GridComp'  , 'RZMC'         ,
-                               'WCSF'       , 'GridComp'  , 'SFMC'         ,
-                               'CAPAC'      , 'GridComp'  , 'INTRWATR'     ,
-                               'TPSNOW'     , 'GridComp'  , 'TPSNOWLAND'   ,
-                               'TPUNST'     , 'GridComp'  , 'TUNSTLAND'    ,
-                               'TPSAT'      , 'GridComp'  , 'TSATLAND'     ,
-                               'TPWLT'      , 'GridComp'  , 'TWLTLAND'     ,
-                               'TPSURF'     , 'GridComp'  , 'TSURFLAND'    ,
-                               'TP1'        , 'GridComp'  , 'TSOIL1'       ,         # CATCH GC: TP1,  ENSAVG GC: TSOIL1TILE
-                               'TP2'        , 'GridComp'  , 'TSOIL2'       ,         # ...
-                               'TP3'        , 'GridComp'  , 'TSOIL3'       ,         # ...
-                               'TP4'        , 'GridComp'  , 'TSOIL4'       ,         # ...
-                               'TP5'        , 'GridComp'  , 'TSOIL5'       ,         # ...
-                               'TP6'        , 'GridComp'  , 'TSOIL6'       ,         # ...
-                               'PRLAND'     , 'GridComp'  , 'PRECTOTCORRLAND'  ,     # assume "corrected" precip
-                               'SNOLAND'    , 'GridComp'  , 'PRECSNOCORRLAND'  ,     # assume "corrected" precip
-                               'TSLAND'     , 'GridComp'  , 'SNOMASLAND'   ,
-                               'SNOWDP'     , 'GridComp'  , 'SNODPLAND'    ,
-                               'EVPSOI'     , 'GridComp'  , 'LHLANDSOIL'   ,
-                               'EVPVEG'     , 'GridComp'  , 'LHLANDTRNS'   ,
-                               'EVPINT'     , 'GridComp'  , 'LHLANDINTR'   ,
-                               'EVPICE'     , 'GridComp'  , 'LHLANDSBLN'   ,
-                               'RUNSURF'    , 'GridComp'  , 'RUNSURFLAND'  ,
-                               'BASEFLOW'   , 'GridComp'  , 'BASEFLOWLAND' ,
-                               'SMLAND'     , 'GridComp'  ,
-                               'QINFIL'     , 'GridComp'  , 'QINFILLAND'   ,
-                               'FRUST'      , 'GridComp'  , 'FRLANDUNST'   ,
-                               'FRSAT'      , 'GridComp'  , 'FRLANDSAT'    ,
-                               'ASNOW'      , 'GridComp'  , 'FRLANDSNO'    ,
-                               'FRWLT'      , 'GridComp'  , 'FRLANDWLT'    ,
-                               'DFPARLAND'  , 'GridComp'  , 'PARDFLAND'    ,
-                               'DRPARLAND'  , 'GridComp'  , 'PARDRLAND'    ,
-                               'SHLAND'     , 'GridComp'  ,
-                               'LHLAND'     , 'GridComp'  ,
-                               'EVLAND'     , 'GridComp'  ,
-                               'LWLAND'     , 'GridComp'  ,
-                               'SWLAND'     , 'GridComp'  ,
-                               'GHLAND'     , 'GridComp'  ,
-                               'TWLAND'     , 'GridComp'  ,
-                               'TELAND'     , 'GridComp'  ,
-                               'DWLAND'     , 'GridComp'  , 'WCHANGELAND'  ,
-                               'DHLAND'     , 'GridComp'  , 'ECHANGELAND'  ,
-                               'SPLAND'     , 'GridComp'  , 'SPSHLAND'     ,
-#                               'SPLH'       , 'GridComp'  , 'SPLHLAND'     ,        # works for Catch only, not yet for CatchCN
-                               'SPWATR'     , 'GridComp'  , 'SPEVLAND'     ,
-                               'SPSNOW'     , 'GridComp'  , 'SPSNLAND'     ,
-                               'PEATCLSM_WATERLEVEL', 'GridComp'  ,
-                               'PEATCLSM_FSWCHANGE' , 'GridComp'  ,
-                           ::
 
   const_1d_lnd_Nt.descr:       'Tile-space,Constant,Time-invariant,Single-Level,Assimilation,Land Surface Model Parameters',
   const_1d_lnd_Nt.template:    '%y4%m2%d2_%h2%n2z.bin',

--- a/GEOSldas_App/ldas_setup
+++ b/GEOSldas_App/ldas_setup
@@ -1283,12 +1283,18 @@ class LDASsetup:
                     shutil.copy2(histrc_file,tmprcfile)
                 else :
                     shutil.copy2(histrc_file,tmprcfile)
-                    GRID='EASE ' + self.rqdExeInp['GRIDNAME'] + ' ' +tmprcfile
-                    if '-CF' in self.rqdExeInp['GRIDNAME'] :
-                        GRID ='CUBE ' + self.rqdExeInp['GRIDNAME'] + ' ' +tmprcfile
-                    _assim = '1' if self.assim else '0'
-                    cmd =self.bindir +'/process_hist.csh '+ str(self.rqdExeInp['LSM_CHOICE']) + ' ' + str(self.rqdExeInp['AEROSOL_DEPOSITION']) + \
-                          ' ' + GRID + ' ' + str(self.rqdExeInp['RUN_IRRIG']) + ' ' + _assim + ' '+ str(self.nens)
+                    if 'EASE' in self.rqdExeInp['GRIDNAME'] :
+                        TMPSTR='OUT1d'
+                    else :
+                        TMPSTR='OUT2d'
+                    cmd = self.bindir +'/process_hist.csh'          + ' ' \
+                        + tmprcfile                                 + ' ' \
+                        + TMPSTR                                    + ' ' \
+                        + self.rqdExeInp['GRIDNAME']                + ' ' \
+                        + str(self.rqdExeInp['LSM_CHOICE'])         + ' ' \
+                        + str(self.rqdExeInp['AEROSOL_DEPOSITION']) + ' ' \
+                        + str(self.rqdExeInp['RUN_IRRIG'])          + ' ' \
+                        + str(self.nens)
                     print(cmd)
                     #os.system(cmd)
                     sp.call(shlex.split(cmd))

--- a/GEOSldas_App/process_hist.csh
+++ b/GEOSldas_App/process_hist.csh
@@ -1,54 +1,73 @@
 #!/bin/csh -f
 
-## I am changed the CUBE/EASE logic
-## if CUBE we produce 2D
-## anything else, SMAP and other offline grids we produce tile space
+# process GEOSldas_HIST.rc (=$HISTRC) template
+#
+# - turn on/off HIST collections depending on tile space
+#   - EASE:      turn on tile-space (1d) output
+#   - otherwise: turn on gridded    (2d) output
+# - turn on/off output variables depending on LSM_CHOICE, AEROSOL_DEPOSITION, and RUN_IRRIG
+# - fill in source 'GridComp' info for variables depending on NENS
 
-setenv    LSM_CHOICE $1
-setenv    AEROSOL_DEPOSITION $2
-setenv    GRID $3
-setenv    GRIDNAME "'$4'"
-setenv    HISTRC $5
-setenv    RUN_IRRIG $6
-setenv    ASSIM  $7
-setenv    NENS $8
+# process command line args
+
+setenv HISTRC             $1         # file name of HIST rc template (GEOSldas_HIST.rc)
+setenv OUTxd              $2         # "OUT1d" or "OUT2d" (to turn on/off collections)
+setenv GRIDNAME         "'$3'"       # full name of grid associated with tile space
+setenv LSM_CHOICE         $4
+setenv AEROSOL_DEPOSITION $5
+setenv RUN_IRRIG          $6
+setenv NENS               $7
+
+# -------------------------------------------------
 
 echo $GRIDNAME
 
-if($ASSIM == 1) then
-   sed -i 's|\#ASSIM|''|g' $HISTRC
-   sed -i '/^\#EASE/d' $HISTRC
-   sed -i '/^\#CUBE/d' $HISTRC
+# uncomment 2d or 1d collections, depending on "OUT1d" (EASE tile space) or "OUT2d" (non-EASE tile space)
+
+if($OUTxd == OUT1d) then
+   sed -i 's|\#OUT1d|''|g' $HISTRC
 else
-   sed -i '/^\#ASSIM/d' $HISTRC
+   sed -i 's|\#OUT2d|''|g' $HISTRC
 endif
 
-if($GRID == CUBE) then
-   sed -i '/^\#EASE/d' $HISTRC
-   sed -i 's|\#CUBE|''|g' $HISTRC
-else
-   sed -i '/^\#CUBE/d' $HISTRC
-   sed -i 's|\#EASE|''|g' $HISTRC
-endif
+# fill in name of grid associated with tile space
+
 sed -i -e  s/\'GRIDNAME\'/$GRIDNAME/g $HISTRC
+
+# set 'GridComp' based on LSM_CHOICE;
+# turn on/off variables associated with CATCHCN, AEROSOL_DEPOSITION, RUN_IRRIG
 
 if($LSM_CHOICE == 1) then
    set GridComp = CATCH
-   sed -i '/^>>>HIST_CATCHCN<<</d' $HISTRC
-   sed -i '/^>>>HIST_CATCHCNCLM45<<</d' $HISTRC
+   sed -i '/^>>>HIST_CATCHCN<<</d'         $HISTRC
+   sed -i '/^>>>HIST_CATCHCNCLM45<<</d'    $HISTRC
 endif
 
 if($LSM_CHOICE == 2) then
    set GridComp = CATCHCN
-   sed -i '/^>>>HIST_CATCHCNCLM45<<</d' $HISTRC
-   sed -i 's/>>>HIST_CATCHCN<<</''/g' $HISTRC
+   sed -i '/^>>>HIST_CATCHCNCLM45<<</d'    $HISTRC
+   sed -i 's/>>>HIST_CATCHCN<<</''/g'      $HISTRC
 endif
 
 if($LSM_CHOICE == 3) then
    set GridComp = CATCHCN
-   sed -i 's/>>>HIST_CATCHCN<<</''/g' $HISTRC
+   sed -i 's/>>>HIST_CATCHCN<<</''/g'      $HISTRC
    sed -i 's/>>>HIST_CATCHCNCLM45<<</''/g' $HISTRC
 endif
+
+if($AEROSOL_DEPOSITION == 0) then
+   sed -i '/^>>>HIST_AEROSOL<<</d'         $HISTRC
+else
+   sed -i 's/>>>HIST_AEROSOL<<</''/g'      $HISTRC
+endif
+
+if($RUN_IRRIG == 0) then
+   sed -i '/^>>>HIST_IRRIG<<</d'           $HISTRC
+else
+   sed -i 's/>>>HIST_IRRIG<<</''/g'        $HISTRC
+endif
+
+# for ensemble simulations, set 'GridComp' to ENSAVG 
 
 if($NENS > 1) then
    set GridComp = ENSAVG
@@ -62,16 +81,6 @@ if($NENS > 1) then
 #   sed -i 's|DATAATM|'DATAATM0000'|g' $HISTRC
 endif
 
+# fill in source 'GridComp' information for output variables
+
 sed -i 's|GridComp|'$GridComp'|g' $HISTRC
-
-if($AEROSOL_DEPOSITION == 0) then
-   sed -i '/^>>>HIST_AEROSOL<<</d' $HISTRC
-else
-   sed -i 's/>>>HIST_AEROSOL<<</''/g' $HISTRC
-endif
-
-if($RUN_IRRIG == 0) then
-   sed -i '/^>>>HIST_IRRIG<<</d' $HISTRC
-else
-   sed -i 's/>>>HIST_IRRIG<<</''/g' $HISTRC
-endif

--- a/GEOSldas_App/process_hist.csh
+++ b/GEOSldas_App/process_hist.csh
@@ -7,7 +7,7 @@
 setenv    LSM_CHOICE $1
 setenv    AEROSOL_DEPOSITION $2
 setenv    GRID $3
-setenv    GRIDNAME $4
+setenv    GRIDNAME "'$4'"
 setenv    HISTRC $5
 setenv    RUN_IRRIG $6
 setenv    ASSIM  $7
@@ -26,11 +26,11 @@ endif
 if($GRID == CUBE) then
    sed -i '/^\#EASE/d' $HISTRC
    sed -i 's|\#CUBE|''|g' $HISTRC
-   sed -i 's|GRIDNAME|'"$GRIDNAME"'|g' $HISTRC
+   sed -i -e  s/\'GRIDNAME\'/$GRIDNAME/g $HISTRC
 else
    sed -i '/^\#CUBE/d' $HISTRC
    sed -i 's|\#EASE|''|g' $HISTRC
-   sed -i 's|GRIDNAME|'"$GRIDNAME"'|g' $HISTRC
+   sed -i -e  s/\'GRIDNAME\'/$GRIDNAME/g $HISTRC
 endif
 
 if($LSM_CHOICE == 1) then

--- a/GEOSldas_App/process_hist.csh
+++ b/GEOSldas_App/process_hist.csh
@@ -26,12 +26,11 @@ endif
 if($GRID == CUBE) then
    sed -i '/^\#EASE/d' $HISTRC
    sed -i 's|\#CUBE|''|g' $HISTRC
-   sed -i -e  s/\'GRIDNAME\'/$GRIDNAME/g $HISTRC
 else
    sed -i '/^\#CUBE/d' $HISTRC
    sed -i 's|\#EASE|''|g' $HISTRC
-   sed -i -e  s/\'GRIDNAME\'/$GRIDNAME/g $HISTRC
 endif
+sed -i -e  s/\'GRIDNAME\'/$GRIDNAME/g $HISTRC
 
 if($LSM_CHOICE == 1) then
    set GridComp = CATCH


### PR DESCRIPTION
Revised and simplified processing of HISTORY template (GEOSldas_HIST.rc).
The revised HISTORY file provides examples for additional 2d HISTORY output.
When running a simulation in EASE grid tile space, 2d latlon-gridded outputs is now possible.  
When running a simulation in cubed-sphere tile space, 2d EASE grid output is now possible.

Successfully 0-diff tested by @gmao-rreichle  after https://github.com/GEOS-ESM/GEOSldas_GridComp/pull/118/commits/1ed302925e9cd3df940c8f68d3057bdba63f9f33

New functionality (2d output from EASE tile space and 2d output on EASE grid) verified by @gmao-rreichle 