### PR TITLE
River routing for GEOSldas

### DIFF
--- a/GEOSldas_App/ldas_setup
+++ b/GEOSldas_App/ldas_setup
@@ -936,6 +936,10 @@ class LDASsetup:
               os.symlink(self.bcs_dir_landshared + 'CO2_MonthlyMean_DiurnalCycle.nc4', \
                           self.inpdir+'/CO2_MonthlyMean_DiurnalCycle.nc4')
 
+           os.symlink(self.bcs_dir_landshared + 'river_input', \
+                       self.inpdir+'/river_input')
+
+
         # create and link restart
         print ("Creating and linking restart...")
         _start = self.begDates[0]
@@ -1369,6 +1373,8 @@ class LDASsetup:
                       ldasrcInp.pop('CO2',None)
                       ldasrcInp.pop('CO2_YEAR',None)
                       ldasrcInp.pop('PRESCRIBE_DVG',None)
+                      
+                   ldasrcInp['River_Routing_FILE']= '../input/river_input/'   
 
                 # create restart item in RC
                    catch_ = self.catch.upper()


### PR DESCRIPTION
This pull request implements the initial setup for river routing in GEOSldas, involving changes to the GEOSldas_GridComp component. It is submitted in parallel with a [similarly titled pull request in GEOSgcm_GridComp](https://github.com/GEOS-ESM/GEOSgcm_GridComp/pull/1023).

As an initial step, this PR makes minimal modifications:

    Updates GEOSldas_App/ldas_setup to link the river_input folder from the bcs land shared directory to the experiment's input directory.

    Adds the corresponding River_Routing_FILE entry to the LDAS.rc configuration file.

Further development and enhancements to the river routing implementation are expected in future commits.