### PR TITLE
fix bug in ASCAT_EUMET soil moisture obs reader

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Fixed bug in ASCAT EUMET soil moisture obs reader.
 - Fixed Restart=1 when the domain is not global.
 
 ### Removed

--- a/GEOSlandassim_GridComp/clsm_ensupd_read_obs.F90
+++ b/GEOSlandassim_GridComp/clsm_ensupd_read_obs.F90
@@ -1951,8 +1951,8 @@ contains
           date_time_tmp%sec   = int(tmp_data(kk, 6))
           
           ! skip if record outside of current assim window
-          if ( datetime_lt_refdatetime( date_time_tmp, date_time_low ) .and.           &
-               datetime_le_refdatetime( date_time_up, date_time_tmp )         ) cycle
+          if ( datetime_lt_refdatetime( date_time_tmp, date_time_low ) .or.              &   ! obs is before start of assim window *or*
+               datetime_le_refdatetime( date_time_up,  date_time_tmp )         ) cycle       ! obs is after  end   of assim window
           
           ! skip if record contains invalid soil moisture value
           if ( tmp_data(kk, 7) > 100. .or. tmp_data(kk, 7) < 0. ) cycle


### PR DESCRIPTION
A bug was discovered in the ASCAT_EUMET soil moisture obs reader. 
In a nutshell, after reading the obs from the files that overlap with the assimilation window, the obs were not properly screened for falling into the assimilation window.  This resulted in ~40% of the observations being assimilation twice.

The fix is trivially 0-diff only in the sense that none of the standard tests engage ASCAT soil moisture assimilation. 

For simulations with ASCAT soil moisture assimilation, the fix is naturally **not** 0-diff.

Successfully 0-diff tested by @gmao-rreichle, 14 Nov 2025

@amfox37 @gmao-qliu 