### PR TITLE
remove 2d lfs collection from GEOSldas_HIST.rc

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Removed
 
+- Removed 2d lfs collection from HISTORY.rc template.
+
 ### Deprecated
 
 -----------------------------

--- a/GEOSldas_App/GEOSldas_HIST.rc
+++ b/GEOSldas_App/GEOSldas_HIST.rc
@@ -13,7 +13,6 @@ EXPID:  GEOSldas_expid
 # pre-defined Collections
 
 COLLECTIONS:
-#OUT2d           'tavg24_2d_lfs_Nx'
 #OUT1d           'tavg24_1d_lnd_Nt'
 #OUT2d           'tavg24_2d_lnd_Nx'
 #                'SMAP_L4_SM_gph'
@@ -74,39 +73,9 @@ EASEv2_M36.LM:           1
 #         simulations because it uses tilecoord.bin, which contains info for all tiles.
 #     - Removed *1d* lfs collection; no longer works in land+landice simulations because of
 #         different tile spaces for CATCH and METFORCE.
-# 
+#     - Removed *2d* lfs collection; this worked for CATCH and METFORCE, but adding LANDICE
+#         fields into the collection fails.
 
-  tavg24_2d_lfs_Nx.descr:       '2d,Daily,Time-Averaged,Single-Level,Assimilation,Land Surface Forcings and States',
-  tavg24_2d_lfs_Nx.nbits:       12,
-  tavg24_2d_lfs_Nx.template:    '%y4%m2%d2_%h2%n2z.nc4',
-  tavg24_2d_lfs_Nx.archive:     '%c/Y%y4',
-  tavg24_2d_lfs_Nx.mode:        'time-averaged',
-  tavg24_2d_lfs_Nx.frequency:   240000,
-  tavg24_2d_lfs_Nx.ref_time:    000000,
-  tavg24_2d_lfs_Nx.format:      'CFIO',
-  tavg24_2d_lfs_Nx.regrid_exch: '../input/tile.data',
-  tavg24_2d_lfs_Nx.regrid_name: 'GRIDNAME',
-  tavg24_2d_lfs_Nx.grid_label:  PC720x361-DC,
-  tavg24_2d_lfs_Nx.deflate:     2,
-  tavg24_2d_lfs_Nx.fields:'Tair'       , 'METFORCE'      ,
-                          'Qair'       , 'METFORCE'      ,
-                          'LWdown'     , 'METFORCE'      ,
-                          'SWdown'     , 'METFORCE'      ,
-                          'Wind'       , 'METFORCE'      ,
-                          'Psurf'      , 'METFORCE'      ,
-                          'Rainf_C'    , 'METFORCE'      ,
-                          'Rainf'      , 'METFORCE'      ,                    
-                          'Snowf'      , 'METFORCE'      ,                    
-                          'RainfSnowf' , 'METFORCE'      ,                    
-                          'RefH'       , 'METFORCE'      ,  
-                          'CATDEF'     , 'GridComp'      ,
-                          'RZEXC'      , 'GridComp'      ,  
-                          'SRFEXC'     , 'GridComp'      ,  
-                          'WESNN1'     , 'GridComp'      ,  
-                          'WESNN2'     , 'GridComp'      ,  
-                          'WESNN3'     , 'GridComp'      ,  
-                          'HLWUP'      , 'GridComp'       ,	
-          ::
 
   tavg24_1d_lnd_Nt.descr:       'Tile-space,Daily,Time-Averaged,Single-Level,Assimilation,Land Surface Diagnostics',
   tavg24_1d_lnd_Nt.nbits:       12,


### PR DESCRIPTION
PR is 0-diff in the sense that any files produced by the NIGHTLY tests should be 0-diff.  However, after merging the PR, the "ifs" collection will no longer be written when the default HISTORY template is used, which should result in a trivial comparison failure.
