### PR TITLE
Fix GEOSlandpert build when MKL is unavailable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Fixed GEOSlandpert build when MKL is unavailable by enabling MKL-specific code paths only when MKL is detected.
+
 ### Removed
 
 - Removed 2d lfs collection from HISTORY.rc template.

--- a/GEOSlandpert_GridComp/CMakeLists.txt
+++ b/GEOSlandpert_GridComp/CMakeLists.txt
@@ -11,6 +11,7 @@ esma_add_library (${this}
   DEPENDENCIES GEOS_LdasShared GEOSens_GridComp GEOSland_GridComp MAPL ${MKL_LIBRARIES}
   INCLUDES ${INC_ESMF} ${MKL_INCLUDE_DIRS})
 
-if (NOT CMAKE_Fortran_COMPILER_ID MATCHES "NAG")
-   target_compile_definitions(${this} PRIVATE MKL_AVAILABLE)
+# Enable MKL paths only when MKL was detected and the compiler supports it.
+if (MKL_FOUND AND NOT CMAKE_Fortran_COMPILER_ID MATCHES "NAG")
+  target_compile_definitions(${this} PRIVATE MKL_AVAILABLE)
 endif ()

--- a/GEOSlandpert_GridComp/random_fields.F90
+++ b/GEOSlandpert_GridComp/random_fields.F90
@@ -311,11 +311,13 @@ contains
     ! assemble spectrum in "wrap-around" order
     i1 = 1
     i2 = this%N_x_fft
+#ifdef MKL_AVAILABLE
     if (this%comm /= MPI_COMM_NULL) then
        call MPI_COMM_Rank(this%node_comm, rank, ierror)
        i1 = sum(this%dim1_counts(1:rank)) + 1
        i2 = sum(this%dim1_counts(1:rank+1))
     endif
+#endif
  
     do j=1,this%N_y_fft
        this%field1_fft(i1:i2,j) = fac*exp(-.25*(lx2kx2(i1:i2)+ly2ky2(j)))  
@@ -395,13 +397,14 @@ contains
     integer :: i, j
     integer :: N_x_fft, N_y_fft
     real :: N_xy_fft_real
+    integer :: n1, n2
 #ifdef MKL_AVAILABLE
     integer :: status
     complex, allocatable :: z_inout(:)
     complex, pointer :: tmp_field(:,:)
     complex, pointer :: tmp_field_dim1(:,:)
     complex, pointer :: tmp_field_dim2(:,:)
-    integer :: n1, n2, npes, rank, ldim1, ldim2, ierror
+    integer :: npes, rank, ldim1, ldim2, ierror
     complex, pointer  :: X(:)
     type (c_ptr) :: cptr
 #else
@@ -624,6 +627,7 @@ contains
     
   end subroutine quit
 
+#ifdef MKL_AVAILABLE
   subroutine win_allocate(this, nx, ny, rc)
      class(random_fields), intent(inout) :: this
      integer, intent(in) :: nx, ny
@@ -662,6 +666,7 @@ contains
      _VERIFY(status)
 
   end subroutine win_deallocate
+#endif
   
 end module Random_fieldsMod
 


### PR DESCRIPTION
### Issue:
GEOSlandpert fails to compile in non-MKL environments (i.e.  my Macbook with Apple silicon) because MKL-specific code paths were being enabled based only on compiler type, not on whether MKL was actually found.
### Fix:
This PR gates MKL_AVAILABLE on MKL_FOUND (and non-NAG compiler) in GEOSlandpert_GridComp/CMakeLists.txt, and wraps MKL-only logic in GEOSlandpert_GridComp/random_fields.F90 with #ifdef MKL_AVAILABLE so builds succeed with and without MKL.