### PR TITLE
Fix NAG Fortran compiler issues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Fixed string matching for EASE tile file to accommodate new "EASE*-Pfafstetter" tile file for runoff routing purposes.
 - Fixed GEOSlandpert build when MKL is unavailable by enabling MKL-specific code paths only when MKL is detected.
+- Fixed NAG Fortran compiler issues.
 
 ### Removed
 

--- a/GEOSlandassim_GridComp/CMakeLists.txt
+++ b/GEOSlandassim_GridComp/CMakeLists.txt
@@ -20,3 +20,8 @@ esma_add_library (${this}
   INCLUDES ${INC_ESMF} ${INC_HDF5})
 
 target_compile_definitions (${this} PRIVATE LDAS_MPI)
+
+# NAG: HDF4 Fortran API (VSFREAD) is called with varying types intentionally
+if (CMAKE_Fortran_COMPILER_ID MATCHES "NAG")
+  target_compile_options(${this} PRIVATE $<$<COMPILE_LANGUAGE:Fortran>:-wmismatch=VSFREAD>)
+endif()

--- a/GEOSldas_App/preprocess_ldas_routines.F90
+++ b/GEOSldas_App/preprocess_ldas_routines.F90
@@ -2735,7 +2735,7 @@ end block
       status = nf90_enddef(NCFOutID)
       ! 4) writing
       
-      status= NF90_PUT_VAR(NCFOutID,seedid ,real(Pert_rseed,kind=8))
+      status= NF90_PUT_VAR(NCFOutID,seedid ,real(Pert_rseed,kind=REAL64))
       
       xstart = 1 + pert_grid_f%i_offg
       ystart = 1 + pert_grid_f%j_offg

--- a/GEOSldas_App/util/inputs/mwRTM_params/mwrtm_bin2nc4.F90
+++ b/GEOSldas_App/util/inputs/mwRTM_params/mwrtm_bin2nc4.F90
@@ -78,7 +78,7 @@ PROGRAM mwrtm_bin2nc4
 
   do n = 1, nVars
 
-     status = NF_DEF_VAR(NCFOutID,trim(shnms(n)) , NF_FLOAT, 1 ,CellID, vid)
+     status = NF_DEF_VAR(NCFOutID,trim(shnms(n)) , NF_FLOAT, 1 ,(/CellID/), vid)
      status = NF_PUT_ATT_TEXT(NCFOutID, vid, 'long_name',               &
           LEN_TRIM(getAttribute(shnms(n), LNAME = 1)),  &
           getAttribute(shnms(n), LNAME = 1) )


### PR DESCRIPTION
This PR will go with below PRs if built with nag:

https://github.com/GEOS-ESM/GEOSgcm_GridComp/pull/1395
https://github.com/GEOS-ESM/GMAO_Shared/pull/240
https://github.com/GEOS-ESM/NCEP_Shared/pull/35

- CMakeLists.txt: suppress -wmismatch for HDF4 VSFREAD calls with varying types
- preprocess_ldas_routines.F90: use REAL64 kind parameter instead of literal kind=8
- mwrtm_bin2nc4.F90: wrap scalar CellID in array constructor for NF_DEF_VAR dimids arg

Successfully 0-diff tested by @weiyuan-jiang on 7 May 2026 https://github.com/GEOS-ESM/GEOSldas_GridComp/pull/170#issuecomment-4406485629