### PR TITLE
Fix memory leaks in GEOSlandassim and GEOSlandpert GridComps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed string matching for EASE tile file to accommodate new "EASE*-Pfafstetter" tile file for runoff routing purposes.
 - Fixed GEOSlandpert build when MKL is unavailable by enabling MKL-specific code paths only when MKL is detected.
 - Fixed NAG Fortran compiler issues.
-
+- Fixed missing deallocate and nullify statements.
+  
 ### Removed
 
 - Removed 2d lfs collection from HISTORY.rc template.

--- a/GEOSlandassim_GridComp/GEOS_LandAssimGridComp.F90
+++ b/GEOSlandassim_GridComp/GEOS_LandAssimGridComp.F90
@@ -2965,10 +2965,23 @@ contains
              call write_pert_rseed(trim(seed_fname), Pert_rseed_r8(:,ens+1))
           enddo
        endif
-    endif ! land_assim
-    
-    ! Call Finalize for every child
-    call MAPL_GenericFinalize(gc, import, export, clock, rc=status)
+     endif ! land_assim
+
+     ! Deallocate module-level arrays allocated in Initialize() -- fix memory leaks
+     if (allocated(tb_nodata))          deallocate(tb_nodata)
+     if (allocated(Pert_rseed))         deallocate(Pert_rseed)
+     if (allocated(Pert_rseed_r8))      deallocate(Pert_rseed_r8)
+     if (associated(N_catl_vec))        deallocate(N_catl_vec)
+     if (associated(low_ind))           deallocate(low_ind)
+     if (associated(l2rf))              deallocate(l2rf)
+     if (associated(rf2f))              deallocate(rf2f)
+     if (associated(tile_coord_rf))     deallocate(tile_coord_rf)
+     if (associated(rf2g))              deallocate(rf2g)
+     if (associated(rf2l))              deallocate(rf2l)
+     if (associated(obs_param))         deallocate(obs_param)
+     
+     ! Call Finalize for every child
+     call MAPL_GenericFinalize(gc, import, export, clock, rc=status)
     _VERIFY(status)
     
     RETURN_(ESMF_SUCCESS)

--- a/GEOSlandassim_GridComp/clsm_ensupd_enkf_update.F90
+++ b/GEOSlandassim_GridComp/clsm_ensupd_enkf_update.F90
@@ -1199,6 +1199,7 @@ contains
           if (allocated( indTiles_ana))       deallocate(indTiles_ana)
 #else
           if (associated(Obs_pred_lH))        deallocate(Obs_pred_lH)
+          if (associated(Observations_lH))    deallocate(Observations_lH)  ! fix memory leak
 
 #endif
 

--- a/GEOSlandassim_GridComp/clsm_ensupd_upd_routines.F90
+++ b/GEOSlandassim_GridComp/clsm_ensupd_upd_routines.F90
@@ -1954,6 +1954,7 @@ contains
     
     if (allocated(ind_tmp))                  deallocate(ind_tmp)
     if (allocated(tmp_ndst2))                deallocate(tmp_ndst2)
+    if (allocated(tmp_wFOV))                 deallocate(tmp_wFOV)   ! fix memory leak
     if (allocated(tmp_weights))              deallocate(tmp_weights)
     if (allocated(tmp_data))                 deallocate(tmp_data)
     

--- a/GEOSlandpert_GridComp/GEOS_LandPertGridComp.F90
+++ b/GEOSlandpert_GridComp/GEOS_LandPertGridComp.F90
@@ -1739,11 +1739,18 @@ contains
     pert_rseed_r8 = real(pert_rseed,kind=ESMF_KIND_R8)
     pert_iseed(:,internal%ens_id+1 - FIRST_ENS_ID) = pert_rseed            
  
-    call MAPL_TimerOff(MAPL, "GenerateRaw")
-    ! End
-    RETURN_(ESMF_SUCCESS)
+     call MAPL_TimerOff(MAPL, "GenerateRaw")
 
-  end subroutine GenerateRaw_ntrmdt
+     ! Explicitly free local allocatable before RETURN_ macro (fix memory leak)
+     if (allocated(pert_rseed)) then
+        deallocate(pert_rseed, stat=status)
+        VERIFY_(status)
+     end if
+
+     ! End
+     RETURN_(ESMF_SUCCESS)
+
+   end subroutine GenerateRaw_ntrmdt
 
   ! IROTUINE: ApplyForcePert -- Compute and apply perts to MetForcing vars
 
@@ -2759,15 +2766,17 @@ contains
        deallocate(tile_data_f, tile_data_p, tile_data_f_all, tile_data_p_all)
     endif
 
-    ! Clean up private internal state
-    if (associated(internal%ForcePert%param)) then
-       deallocate(internal%ForcePert%param, stat=status)
-       VERIFY_(status)
-    end if
-    if (associated(internal%PrognPert%param)) then
-       deallocate(internal%PrognPert%param, stat=status)
-       VERIFY_(status)
-    end if
+     ! Clean up private internal state
+     if (associated(internal%ForcePert%param)) then
+        deallocate(internal%ForcePert%param, stat=status)
+        VERIFY_(status)
+        nullify(force_pert_param)   ! fix dangling module-level pointer
+     end if
+     if (associated(internal%PrognPert%param)) then
+        deallocate(internal%PrognPert%param, stat=status)
+        VERIFY_(status)
+        nullify(progn_pert_param)   ! fix dangling module-level pointer
+     end if
     if (allocated(internal%ForcePert%DataPrv)) then
        deallocate(internal%ForcePert%DataPrv, stat=status)
        VERIFY_(status)
@@ -2800,18 +2809,30 @@ contains
        VERIFY_(status)
     end if
 
-    if (allocated(fpert_enavg)) then
-       deallocate(fpert_enavg, stat=status)
-       VERIFY_(status)
-    end if
-    if (allocated(ppert_enavg)) then
-       deallocate(ppert_enavg, stat=status)
-       VERIFY_(status)
-    end if
+     if (allocated(fpert_enavg)) then
+        deallocate(fpert_enavg, stat=status)
+        VERIFY_(status)
+     end if
+     if (allocated(ppert_enavg)) then
+        deallocate(ppert_enavg, stat=status)
+        VERIFY_(status)
+     end if
 
-    call clear_rf()
-    ! Call Finalize for every child
-    call MAPL_GenericFinalize(gc, import, export, clock, rc=status)
+     if (associated(pert_iseed)) then     ! fix memory leak: module-level pointer never freed
+        deallocate(pert_iseed, stat=status)
+        VERIFY_(status)
+        nullify(pert_iseed)
+     end if
+
+     call clear_rf()
+
+     ! Deallocate the internal state struct itself (fix memory leak)
+     deallocate(internal, stat=status)
+     VERIFY_(status)
+     wrap%ptr => null()
+
+     ! Call Finalize for every child
+     call MAPL_GenericFinalize(gc, import, export, clock, rc=status)
     VERIFY_(status)
 
     ! End


### PR DESCRIPTION
24-member simulations with perturbations on the c360 tile space crash after a few data-days.  The exact data-time of the crash is different for each run.   The error messages suggests that insufficient memory is the problem. 

This PR fixes missing deallocate and nullify statements.  These fixes should help address the crashes, but it remains unclear if the changes are sufficient to resolve the problem. 

Specifically, the following fixes are included: 

- GEOSlandassim: add deallocate(Observations_lH) in non-MPI path of get_enkf_increments (clsm_ensupd_enkf_update.F90); pointer was allocated every assimilation cycle but never freed
- GEOSlandassim: add deallocate(tmp_wFOV) to cleanup block of get_obs_pred (clsm_ensupd_upd_routines.F90); omitted alongside four sibling arrays that were already freed
- GEOSlandassim: add comprehensive deallocate calls in Finalize() for all module-level variables allocated in Initialize() (GEOS_LandAssimGridComp.F90): tb_nodata, Pert_rseed, Pert_rseed_r8, N_catl_vec, low_ind, l2rf, rf2f, tile_coord_rf, rf2g, rf2l, obs_param
- GEOSlandpert: add explicit deallocate(pert_rseed) before RETURN_ macro in GenerateRaw_ntrmdt, consistent with ApplyForcePert/ApplyPrognPert
- GEOSlandpert: add deallocate(pert_iseed) + nullify in Finalize(); module-level pointer was never freed
- GEOSlandpert: add deallocate(internal) + nullify(wrap%ptr) in Finalize(); T_LANDPERT_STATE struct itself was never freed
- GEOSlandpert: nullify force_pert_param and progn_pert_param after their targets are deallocated in Finalize() to avoid dangling pointers

Successfully 0-diff tested by @gmao-rreichle on 19 July 2026

cc: @gmao-qliu @biljanaorescanin @gmao-rreichle 
